### PR TITLE
Add reverse build workflows and enhance local workflow script

### DIFF
--- a/.github/workflows/build-reverse.yaml
+++ b/.github/workflows/build-reverse.yaml
@@ -1,18 +1,15 @@
-name: build
+name: build-reverse
 
 on:
-  push:
-      branches: [ main ]
-  schedule:
-    - cron: '30 4 * * *'
   workflow_dispatch:
 
 jobs:
-  Blender-releases-Dockerhub:
+  Blender-releases-Dockerhub-Reverse:
     runs-on: ubuntu-latest
     env:
       MIN_FREE_GB: '15'
       DISABLE_PODMAN_PRUNE: '0'
+      REVERSE_BUILD_ORDER: '1'
     steps:
       - uses: actions/checkout@v4
       - name: Snapshot workspace storage
@@ -46,11 +43,12 @@ jobs:
           DOCKER_REGISTRY: docker.io
         run: python3 build.py
 
-  Blender-releases-GHCR:
+  Blender-releases-GHCR-Reverse:
     runs-on: ubuntu-latest
     env:
       MIN_FREE_GB: '15'
       DISABLE_PODMAN_PRUNE: '0'
+      REVERSE_BUILD_ORDER: '1'
     steps:
       - uses: actions/checkout@v4
       - name: Snapshot workspace storage
@@ -79,11 +77,9 @@ jobs:
         uses: redhat-actions/podman-login@v1
         with:
           registry: ghcr.io
-          username: ${{github.actor}}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build.py
         env:
           DOCKER_REGISTRY: ghcr.io
         run: python3 build.py
-
-

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-    "iis.configDir": ""
+    "iis.configDir": "",
+    "cSpell.words": [
+        "blenderkit",
+        "Containerfile",
+        "multiversion",
+        "winerror"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -12,11 +12,25 @@ Details follows if you are interested in development of the images.
 
 ## How it is done
 
-This repository is primarily focused on automated builds in Github Actions.
-Doing the build locally would require some repetetive work, it could be scripted (pull requests welcomed!), but for us it is not use case we need.
+This repository is primarily focused on automated builds in Github Actions, but you can also rehearse the workflow locally if you need to debug issues before pushing changes.
 
 Automated builds are done by Github actions in `.github/workflows/build.yml` file.
-You can clone this repo and run it on its own.
+You can clone this repo and run it on its own. By default the pipeline iterates releases from oldest to newest to ensure legacy builds still run, but you can flip the direction by exporting `REVERSE_BUILD_ORDER=1` before calling `build.py` (our reverse-order workflow in CI does this). When debugging locally you can also resume from a specific release via `START_VERSION` (example: `START_VERSION=4.2 pwsh -File scripts/local-workflow.ps1`).
+
+### Local dry run (Windows or PowerShell)
+
+1. Install Python 3.10+ and Docker Desktop (or Podman) and make sure both `python` and `docker` are on your `PATH`.
+2. Login to the registry you plan to push to (`docker login docker.io` or equivalent). If you only want to test the build flow locally, you can skip pushing.
+3. From the repository root, run:
+
+	```powershell
+	pwsh -File scripts/local-workflow.ps1 -Registry docker.io -Runtime docker
+	```
+
+	- The script mirrors the CI steps: checks free disk space, installs Python dependencies, prints `docker info`, and calls `python build.py`.
+	- Pushing images is disabled by default (`SKIP_IMAGE_PUSH=1`). Pass `-PushImages` to enable it.
+	- Set `-Runtime podman` if you have Podman installed instead of Docker.
+	- You can skip dependency installation with `-SkipDependencyInstall` when re-running quickly.
 
 ### Single version
 Containerfile for single version is available in `single-version` folder.

--- a/build.py
+++ b/build.py
@@ -1,18 +1,41 @@
 import os
 import subprocess
 import requests
-import pathlib
 import tarfile
 import shutil
 import get_blender_release as gbr
 
 
+MIN_FREE_GB = float(os.environ.get("MIN_FREE_GB", "12"))
+CONTAINER_RUNTIME = os.environ.get("CONTAINER_RUNTIME", "podman")
+SKIP_IMAGE_PUSH = os.environ.get("SKIP_IMAGE_PUSH") == "1"
+REVERSE_BUILD_ORDER = os.environ.get("REVERSE_BUILD_ORDER") == "1"
+
+def runtime_cmd(*args):
+        return [CONTAINER_RUNTIME, *args]
+
 def build_containers(registry: str):
     releases = gbr.get_stable_and_prereleases(os="linux", arch="x64", min_ver=(2, 93))
-    releases = gbr.order_releases(releases)
+    releases = list(gbr.order_releases(releases))
+    if REVERSE_BUILD_ORDER:
+        releases = list(reversed(releases))
+        print("-> REVERSE_BUILD_ORDER=1, building newest to oldest")
+    else:
+        print("-> Building oldest to newest (default)")
+    start_version = os.environ.get("START_VERSION")
+    if start_version:
+        try:
+            start_tuple = tuple(int(part) for part in start_version.split('.'))
+            releases = [r for r in releases if r.version <= start_tuple]
+            print(f"-> START_VERSION={start_version}, remaining releases: {len(releases)}")
+        except ValueError:
+            print(f"-> WARNING: invalid START_VERSION '{start_version}', ignoring filter")
     prev_version = None
     for i, release in enumerate(releases):
         print(f"\n\n\n====== Blender {release.version} ======")
+
+        log_disk_usage(f"before {release.version}")
+        ensure_disk_headroom(MIN_FREE_GB)
 
         build_dir = os.path.join(os.path.dirname(__file__), "build", f"{release.version[0]}.{release.version[1]}")
         ok = build_container(release.url, release.version, release.stage, build_dir, registry)
@@ -20,7 +43,7 @@ def build_containers(registry: str):
             print(f"✅ {release.version} {release.stage} single build OK")
         else:
             print(f"❌ {release.version} {release.stage} single build FAILED")
-        
+
         if i == 0:
             ok = multi_start(release.url, release.version, release.stage, build_dir)
             prev_version = release.version
@@ -29,6 +52,8 @@ def build_containers(registry: str):
             else:
                 print(f"❌ {release.version} {release.stage} multi build starter FAILED")
             clean_build_dir(build_dir)
+            log_disk_usage(f"after cleanup {release.version}")
+            prune_podman_storage(f"post {release.version}")
             continue
 
         ok = multi_add(release.url, release.version, prev_version, build_dir)
@@ -39,28 +64,41 @@ def build_containers(registry: str):
         else:
             print(f"❌ {release.version} {release.stage} multi build FAILED")
         clean_build_dir(build_dir)
-        
+        log_disk_usage(f"after cleanup {release.version}")
+        prune_podman_storage(f"post {release.version}")
+
         if i == len(releases) - 1:
             ok = multi_push(release.version, registry)
+            prune_podman_storage("post multi push")
 
 
 def clean_build_dir(dir: str):
-    shutil.rmtree(dir)
-    print(f"-> CLEANED directory {dir}")
+    if os.path.isdir(dir):
+        shutil.rmtree(dir)
+        print(f"-> CLEANED directory {dir}")
+    else:
+        print(f"-> SKIPPED cleanup, directory {dir} not found")
 
 
-def download_file(url, dst):
+def download_file(url, dst, force=False):
     if os.path.exists(dst):
-        print(f"- skipping download, {dst} exists")
-        return
+        if force:
+            os.remove(dst)
+        else:
+            print(f"- skipping download, {dst} exists")
+            return
 
     print(f"- downloading {url} to {dst}", end="")
+    tmp_dst = dst + ".tmp"
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
     with requests.get(url, stream=True) as r:
         r.raise_for_status()
-        with open(dst, 'wb') as f:
-            for chunk in r.iter_content(chunk_size=8192):
-                f.write(chunk)
+        with open(tmp_dst, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    f.write(chunk)
     print("✅ download complete")
+    os.replace(tmp_dst, dst)
 
 
 def extract_tar(tar_path, target_dir):
@@ -69,9 +107,21 @@ def extract_tar(tar_path, target_dir):
         print(f"- skipping extraction, {dst} exists")
         return
 
+    print(f"- validating archive {tar_path}")
+    with tarfile.open(tar_path) as tar:
+        try:
+            tar.getmembers()
+        except EOFError:
+            print("-> ERROR: archive truncated, deleting and retrying download")
+            os.remove(tar_path)
+            raise RuntimeError("Corrupted archive")
+
     print(f"- extracting {tar_path} -> {target_dir}")
     with tarfile.open(tar_path) as tar:
-        tar.extractall(path=target_dir)
+        if os.name == "nt":
+            safe_extract_with_symlink_copy(tar, target_dir)
+        else:
+            tar.extractall(path=target_dir)
 
     for item in os.listdir(target_dir):
         if item == "blender.tar.xz":
@@ -80,6 +130,50 @@ def extract_tar(tar_path, target_dir):
         print(f"- moving {src} -> {dst}")
         shutil.move(src, dst)
     print("✅ extraction complete")
+
+
+def safe_extract_with_symlink_copy(tar: tarfile.TarFile, target_dir: str):
+    for member in tar.getmembers():
+        try:
+            tar.extract(member, target_dir)
+        except OSError as exc:
+            win_err = getattr(exc, "winerror", None)
+            if win_err == 1314 and (member.issym() or member.islnk()):
+                print(f"-> symlink fallback for {member.name} -> {member.linkname}")
+                copy_link_target(tar, member, target_dir)
+            else:
+                raise
+
+
+def copy_link_target(tar: tarfile.TarFile, member: tarfile.TarInfo, target_dir: str):
+    try:
+        target_member = tar.getmember(member.linkname)
+    except KeyError:
+        print(f"-> WARNING: link target {member.linkname} missing; skipping {member.name}")
+        return
+
+    dest_path = os.path.join(target_dir, member.name)
+    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+
+    if target_member.isdir():
+        tar.extract(target_member, target_dir)
+        source_dir = os.path.join(target_dir, target_member.name)
+        if os.path.exists(dest_path):
+            shutil.rmtree(dest_path)
+        shutil.copytree(source_dir, dest_path)
+        return
+
+    extracted_path = os.path.join(target_dir, target_member.name)
+    if not os.path.exists(extracted_path):
+        tar.extract(target_member, target_dir)
+
+    fileobj = tar.extractfile(target_member)
+    if fileobj is None:
+        with open(extracted_path, 'rb') as src, open(dest_path, 'wb') as dst:
+            shutil.copyfileobj(src, dst)
+    else:
+        with fileobj as src, open(dest_path, 'wb') as dst:
+            shutil.copyfileobj(src, dst)
 
 
 SINGLE_CONTAINERFILE = """FROM docker.io/accetto/ubuntu-vnc-xfce-opengl-g3
@@ -91,7 +185,7 @@ ENTRYPOINT [ "/usr/bin/tini", "--", "/dockerstartup/startup.sh" ]
 """
 
 def generate_single_containerfile(version: tuple, stage: str):
-    """Generate single version Containerfile. Single version Container contais just one version of Blender."""
+    """Generate single version Containerfile. Single version Container contains just one version of Blender."""
     dockerfile = SINGLE_CONTAINERFILE.format(
         x=version[0],
         y=version[1],
@@ -128,13 +222,23 @@ def build_container(url: str, version: tuple, stage: str, build_dir: str, regist
     if type(version) != tuple:
         print(f"Invalid version {version}")
         return False
-    
+
     print(f"=== Building {version} ===")
     os.makedirs(build_dir, exist_ok=True)
 
     tar_path = os.path.join(build_dir, "blender.tar.xz")
-    download_file(url, tar_path)
-    extract_tar(tar_path, build_dir)
+    attempts = 2
+    for attempt in range(attempts):
+        download_file(url, tar_path, force=attempt > 0)
+        try:
+            extract_tar(tar_path, build_dir)
+            break
+        except RuntimeError as exc:
+            if attempt == attempts - 1:
+                print(f"-> FAILED extraction after retry: {exc}")
+                return False
+            print("-> Retrying download due to extraction failure")
+            continue
 
     containerfile = generate_single_containerfile(version, stage)
     cfpath = os.path.join(build_dir, "Containerfile")
@@ -142,30 +246,38 @@ def build_container(url: str, version: tuple, stage: str, build_dir: str, regist
         file.write(containerfile)
 
     print(os.listdir(build_dir))
-    cmd = [
-        'podman', 'build',
+    cmd = runtime_cmd(
+        'build',
         '-f', cfpath,
         '-t', f'{registry}/blenderkit/headless-blender:blender-{version[0]}.{version[1]}',
         '.'
-    ]
+    )
     print(f"- running command {' '.join(cmd)}")
     pb = subprocess.run(cmd, cwd=build_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE,)
 
     print( 'exit status:', pb.returncode )
     print( 'stdout:', pb.stdout.decode() )
     print( 'stderr:', pb.stderr.decode() )
-    if pb.returncode!= 0:    
+    if pb.returncode!= 0:
         return False
     print("-> SINGLE BUILD DONE")
 
-    print("-> PUSHING SINGLE IMAGE")
-    pp = subprocess.run(['podman', 'push', f'{registry}/blenderkit/headless-blender:blender-{version[0]}.{version[1]}'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    print( 'exit status:', pp.returncode )
-    print( 'stdout:', pp.stdout.decode() )
-    print( 'stderr:', pp.stderr.decode() )
-    if pp.returncode!= 0:
-        return False
-    print("-> PUSH DONE")
+    if SKIP_IMAGE_PUSH:
+        print("-> SKIPPING PUSH (SKIP_IMAGE_PUSH=1)")
+    else:
+        print("-> PUSHING SINGLE IMAGE")
+        push_cmd = runtime_cmd('push', f'{registry}/blenderkit/headless-blender:blender-{version[0]}.{version[1]}')
+        pp = subprocess.run(
+            push_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        print( 'exit status:', pp.returncode )
+        print( 'stdout:', pp.stdout.decode() )
+        print( 'stderr:', pp.stderr.decode() )
+        if pp.returncode!= 0:
+            return False
+        print("-> PUSH DONE")
 
     remove_image(f"{registry}/blenderkit/headless-blender:blender-{version[0]}.{version[1]}")
 
@@ -188,12 +300,12 @@ def multi_start(url: str, version: tuple,  stage: str, build_dir: str) -> bool:
     cfpath = os.path.join(build_dir, "Containerfile")
     with open(cfpath, "w") as file:
         file.write(containerfile)
-    
+
     print(os.listdir(build_dir))
-    cmd = ['podman', 'build', '-f', cfpath, '-t', f'blender_{version[0]}_{version[1]}:latest', '.']
+    cmd = runtime_cmd('build', '-f', cfpath, '-t', f'blender_{version[0]}_{version[1]}:latest', '.')
     print(f"- running command {' '.join(cmd)}")
     pb = subprocess.run(cmd, cwd=build_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    
+
     print( 'exit status:', pb.returncode )
     print( 'stdout:', pb.stdout.decode() )
     print( 'stderr:', pb.stderr.decode() )
@@ -220,10 +332,10 @@ def multi_add(url: str, version: tuple, prev_version:tuple, build_dir:str) -> bo
         file.write(containerfile)
 
     print(os.listdir(build_dir))
-    cmd = ['podman', 'build', '-f', cfpath, '-t', f'blender_{version[0]}_{version[1]}:latest', '.']
+    cmd = runtime_cmd('build', '-f', cfpath, '-t', f'blender_{version[0]}_{version[1]}:latest', '.')
     print(f"- running command {' '.join(cmd)}")
     pb = subprocess.run(cmd, cwd=build_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    
+
     print( 'exit status:', pb.returncode )
     print( 'stdout:', pb.stdout.decode() )
     print( 'stderr:', pb.stderr.decode() )
@@ -234,14 +346,17 @@ def multi_add(url: str, version: tuple, prev_version:tuple, build_dir:str) -> bo
 def multi_push(version: tuple, registry: str) -> bool:
     """Push multiversion Blender container."""
     print(f"=== Pushing multi {version} as headless-blender:multi-version ===")
-    cmd = ["podman", "image", "tag", f"blender_{version[0]}_{version[1]}", f"{registry}/blenderkit/headless-blender:multi-version"]
+    if SKIP_IMAGE_PUSH:
+        print("-> SKIPPING MULTI PUSH (SKIP_IMAGE_PUSH=1)")
+        return True
+    cmd = runtime_cmd("image", "tag", f"blender_{version[0]}_{version[1]}", f"{registry}/blenderkit/headless-blender:multi-version")
     print(f"- running command {' '.join(cmd)}")
     pt = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     print( 'exit status:', pt.returncode )
     print( 'stdout:', pt.stdout.decode() )
     print( 'stderr:', pt.stderr.decode() )
 
-    cmd = ['podman', 'push', f'{registry}/blenderkit/headless-blender:multi-version']
+    cmd = runtime_cmd('push', f'{registry}/blenderkit/headless-blender:multi-version')
     print(f"- running command {' '.join(cmd)}")
     pp = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     print( 'exit status:', pp.returncode )
@@ -254,7 +369,7 @@ def multi_push(version: tuple, registry: str) -> bool:
 
 
 def remove_image(name):
-    cmd = ['podman', 'rmi', name]
+    cmd = runtime_cmd('rmi', name)
     print(f"- running command {' '.join(cmd)}")
     p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     print( 'exit status:', p.returncode )
@@ -264,6 +379,49 @@ def remove_image(name):
         print(f"-> FAILED to remove {name}")
     else:
         print(f"-> REMOVED image {name}")
+
+
+def prune_podman_storage(reason: str):
+    if os.environ.get("DISABLE_PODMAN_PRUNE") == "1":
+        print(f"-> Skipping podman prune ({reason})")
+        return
+
+    print(f"-> Pruning podman storage ({reason})")
+    cmd = runtime_cmd('system', 'prune', '-a', '--volumes', '--force')
+    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    print('exit status:', p.returncode)
+    print('stdout:', p.stdout.decode())
+    print('stderr:', p.stderr.decode())
+    if p.returncode != 0:
+        print("-> Podman prune failed")
+
+
+def _bytes_to_gib(value: int) -> float:
+    return value / (1024 ** 3)
+
+
+def log_disk_usage(label: str):
+    total, used, free = shutil.disk_usage("/")
+    print(
+        f"[disk] {label}: total {_bytes_to_gib(total):.1f} GiB | "
+        f"used {_bytes_to_gib(used):.1f} GiB | free {_bytes_to_gib(free):.1f} GiB"
+    )
+
+
+def ensure_disk_headroom(min_free_gb: float, strict: bool = False):
+    _, _, free = shutil.disk_usage("/")
+    free_gb = _bytes_to_gib(free)
+    if free_gb < min_free_gb:
+        if strict:
+            raise RuntimeError(
+                f"Insufficient disk space: {free_gb:.1f} GiB free, need at least {min_free_gb:.1f} GiB"
+            )
+        else:
+            print(
+                'stderr:',
+                f"-> WARNING: Low disk space: {free_gb:.1f} GiB free, "
+                f"recommended at least {min_free_gb:.1f} GiB"
+            )
 
 
 if __name__ == '__main__':

--- a/scripts/local-workflow.ps1
+++ b/scripts/local-workflow.ps1
@@ -1,0 +1,85 @@
+param(
+    [string]$PythonExe = "python",
+    [string]$Registry = "docker.io",
+    [string]$Runtime = "docker",
+    [string]$StartVersion,
+    [switch]$SkipDependencyInstall,
+    [switch]$PushImages
+)
+
+$ErrorActionPreference = "Stop"
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptRoot
+Push-Location $repoRoot
+try {
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+    if (-not $env:MIN_FREE_GB) {
+        $env:MIN_FREE_GB = "12"
+    }
+    $env:DOCKER_REGISTRY = $Registry
+    $env:CONTAINER_RUNTIME = $Runtime
+    Write-Step "Validating container runtime '$Runtime'"
+    $runtimeCmd = Get-Command $Runtime -ErrorAction SilentlyContinue
+    if (-not $runtimeCmd) {
+        throw "Container runtime '$Runtime' not found in PATH. Install Docker Desktop or Podman and retry."
+    }
+    try {
+        $runtimeInfo = & $Runtime --version 2>$null
+        if (-not $runtimeInfo) {
+            $runtimeInfo = & $Runtime version 2>$null
+        }
+        Write-Host $runtimeInfo
+    } catch {
+        throw "Failed to execute '$Runtime --version'. Ensure $Runtime is installed correctly."
+    }
+    $isDocker = $Runtime -match 'docker'
+    if ($isDocker -and ($runtimeInfo -notmatch 'Docker')) {
+        Write-Warning "Runtime '$Runtime' does not appear to be Docker. Output: $runtimeInfo"
+    }
+    if (-not $PushImages) {
+        $env:SKIP_IMAGE_PUSH = "1"
+        Write-Step "Image push disabled for local run"
+    } else {
+        Write-Step "Image push ENABLED"
+    }
+    if ($StartVersion) {
+        $env:START_VERSION = $StartVersion
+        Write-Step "Starting build at version $StartVersion"
+    }
+
+    Write-Step "Disk snapshot"
+    $driveLetter = (Get-Location).Path.Substring(0,1)
+    $drive = Get-PSDrive -Name $driveLetter -ErrorAction Stop
+    $driveInfo = Get-CimInstance -ClassName Win32_LogicalDisk -Filter "DeviceID='$($driveLetter):'"
+    if (-not $driveInfo) {
+        throw "Unable to read disk information for ${driveLetter}:"
+    }
+    $sizeBytes = if ($driveInfo.Size) { $driveInfo.Size } else { throw "Unable to determine size of drive ${driveLetter}:" }
+    $totalGB = [math]::Round($sizeBytes / 1GB, 2)
+    $freeGB = [math]::Round($driveInfo.FreeSpace / 1GB, 2)
+    $minFree = [double]$env:MIN_FREE_GB
+    Write-Host ("Drive {0}: total {1:N1} GB | free {2:N1} GB" -f $driveLetter, $totalGB, $freeGB)
+    if ($freeGB -lt $minFree) {
+        throw "Free space ${freeGB} GB is below required ${minFree} GB"
+    }
+
+    if (-not $SkipDependencyInstall) {
+        Write-Step "Installing Python requirements"
+        & $PythonExe -m pip install --upgrade pip
+        & $PythonExe -m pip install -r requirements.txt
+    }
+
+    Write-Step "Printing docker info"
+    & $Runtime info | Out-Host
+
+    Write-Step "Running build.py"
+    & $PythonExe (Join-Path $repoRoot 'build.py')
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
- Introduced `build-reverse.yaml` for reverse order builds on Dockerhub and GHCR.
- Updated `build.yaml` to include minimum free space checks and workspace snapshots.
- Enhanced `build.py` to support reverse build order and added disk space validation.
- Created `local-workflow.ps1` for local testing with improved error handling and environment setup.
- Updated `README.md` with instructions for local dry runs and reverse build usage.